### PR TITLE
Update Package Installation Workflow

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,7 +21,6 @@ def test_pip_packages(host, pkg):
 @pytest.mark.parametrize(
     "f",
     [
-        "/var/local/cyhy/runner",
         "/var/log/cyhy",
         "/lib/systemd/system/cyhy-runner.service",
     ],

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,6 +12,14 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
+@pytest.mark.parametrize(
+    "pkg", ["python3-daemon", "python3-docopt", "python3-lockfile", "python3-requests"]
+)
+def test_packages(host, pkg):
+    """Test that the appropriate packages were installed."""
+    assert host.package(pkg).is_installed
+
+
 @pytest.mark.parametrize("pkg", ["cyhy-runner"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,35 +1,9 @@
 ---
 # tasks file for cyhy_runner
 
-- name: Create the /var/local/cyhy/runner directory
-  file:
-    path: /var/local/cyhy/runner
-    state: directory
-    mode: 0755
-
-- name: Download and untar the cyhy-runner tarball
-  # ansible-lint E208 gives an error if we don't specify the mode, but
-  # we definitely don't want to do that here since it will override
-  # the permissions on the files in the archive.
-  unarchive: # noqa 208
-    src: "https://api.github.com/repos/cisagov/cyhy-runner/tarball/develop"
-    dest: /var/local/cyhy/runner
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-#
-# Now we need to install the cyhy-runner dependencies
-#
-- name: Install docutils, since cyhy-runner needs it
+- name: Install the cyhy-runner package
   pip:
-    name:
-      - docutils
-
-- name: Install python dependencies for cyhy-runner
-  pip:
-    chdir: /var/local/cyhy/runner
-    requirements: requirements.txt
+    name: https://api.github.com/repos/cisagov/cyhy-runner/tarball/develop
 
 - name: Create some directories that cyhy-runner requires
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for cyhy_runner
 
+- name: Install system versions of the Python packages that cyhy-runner needs
+  package:
+    name:
+      - python3-daemon
+      - python3-docopt
+      - python3-lockfile
+      - python3-requests
+
 - name: Install the cyhy-runner package
   pip:
     name: https://api.github.com/repos/cisagov/cyhy-runner/tarball/develop


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the installation of the [cisagov/cyhy-runner](https://github.com/cisagov/cyhy-runner) package. Required packages are installed as system packages instead of through `pip`. The [cisagov/cyhy-runner](https://github.com/cisagov/cyhy-runner) package itself is installed directly instead of manually downloading and extracting the tarball.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

Now that the [cisagov/cyhy-runner](https://github.com/cisagov/cyhy-runner) project is in-line with our modern development practices I thought it would be good to update the Ansible role. We try to avoid installing requirements with `pip` when possible unless a `venv` is used.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass and I deployed an nmap instance to my testing environment and confirmed that scanning works as expected.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
