### PR TITLE
Limit usage of the `--break-system-packages` flag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,9 +21,9 @@
     # The extra argument is necessary on Debian 12, which correctly
     # recognizes that the local Python is externally managed
     # (i.e. managed via the system package manager and not by pip).
-    # The extra argument is understood by pip on Debian and Kali
+    # The extra argument is understood by pip on Debian 12 and Kali
     # systems, but not others.
-    extra_args: "{{ ansible_distribution is in ['Debian', 'Kali'] | ternary('--break-system-packages', omit) }}"
+    extra_args: "{{ (ansible_distribution == 'Kali' or (ansible_distribution == 'Debian' and ansible_distribution_release == 'bookworm')) | ternary('--break-system-packages', omit) }}"
     name: https://api.github.com/repos/cisagov/cyhy-runner/tarball/develop
 
 - name: Create some directories that cyhy-runner requires


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Thie pull request adjusts the logic for adding the `--break-system-packages` flag as an extra argument to only occur on Debian Bookworm and Kali Linux systems.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This flag requires [pip 23.0.1](https://pip.pypa.io/en/stable/news/#v23-0-1) to function. This version of [pip] is only available as a system package on Debian 12 (Bookworm) and Kali LInux (which is currently based on Debian Bookworm). The Docker images we use for testing upgrade the [pip] package outside of the system package offered and so although tests pass the role will fail if run on a non-Debian Bookworm or Kali LInux system as seen [here](https://github.com/cisagov/openvpn-packer/actions/runs/4386429058/jobs/7680506650). This is the same issue as in https://github.com/cisagov/ansible-role-pca-gophish-composition/pull/43 and https://github.com/cisagov/ansible-role-openvpn/pull/72.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this branch to create new [CyHy `nmap` AMIs](https://github.com/cisagov/cyhy_amis). They failed using the `develop` branch in contrast.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[pip]: https://pypi.org/project/pip/