### PR TITLE
Remove support for outdated platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,6 @@ jobs:
           - arm64
         platform:
           - amazonlinux2023-systemd
-          - debian10-systemd
           - debian11-systemd
           - debian12-systemd
           - debian13-systemd
@@ -194,7 +193,6 @@ jobs:
           - fedora40-systemd
           - fedora41-systemd
           - kali-systemd
-          - ubuntu-20-systemd
           - ubuntu-22-systemd
           - ubuntu-24-systemd
         scenario:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,7 +30,6 @@ galaxy_info:
         - "2023"
     - name: Debian
       versions:
-        - buster
         - bullseye
         - bookworm
         - trixie
@@ -44,7 +43,6 @@ galaxy_info:
         - "2023"
     - name: Ubuntu
       versions:
-        - focal
         - jammy
         - noble
   role_name: cyhy_runner

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,24 +24,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-amd64
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest
     name: debian11-systemd-amd64
     platform: amd64
@@ -161,24 +143,6 @@ platforms:
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora41-ansible:latest
     name: fedora41-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd-amd64
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd-arm64
     platform: arm64
     pre_build_image: true
     privileged: true


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes support for outdated platforms.

## 💭 Motivation and context ##

[cisagov/cyhy-runner](https://github.com/cisagov/cyhy-runner) requires at least Python 3.9 as of cisagov/cyhy-runner#34, and Debian Buster (10) and Ubuntu Focal (20.04) do not offer anything later than Python 3.8.  This is currently [breaking GitHub Actions for this repository](https://github.com/cisagov/ansible-role-cyhy-runner/actions/runs/13645732724).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Mark Debian Buster and Ubuntu Focal GitHub Actions checks as not required.
