### PR TITLE
Create additional directories needed by `cisagov/cyhy-runner`

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -43,6 +43,8 @@ def test_pip_packages(host, pkg):
     "directory",
     [
         {"mode": "0o755", "path": "/var/cyhy/runner"},
+        {"mode": "0o755", "path": "/var/cyhy/runner/done"},
+        {"mode": "0o755", "path": "/var/cyhy/runner/running"},
         {"mode": "0o755", "path": "/var/log/cyhy"},
     ],
 )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,8 @@
     state: directory
   loop:
     - /var/cyhy/runner
+    - /var/cyhy/runner/done
+    - /var/cyhy/runner/running
     - /var/log/cyhy
 
 # Copy the systemd unit file


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request creates the `done` and `running` sub-directories that are needed by [cisagov/cyhy-runner].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Though [cisagov/cyhy-runner] will create the directories if they are missing, the owner will be whatever is running the project. This is especially problematic if [cisagov/cyhy-runner] is used in a systemd service that runs under `root` (which we do). Since this will prevent the non-`root` user from reading/writing to the directories it is instead ideal to create them ahead of time with the appropriate ownership.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[cisagov/cyhy-runner]: https://github.com/cisagov/cyhy-runner